### PR TITLE
Fix asset path for the CustomScaler panel

### DIFF
--- a/src/Customscaler.cpp
+++ b/src/Customscaler.cpp
@@ -458,7 +458,7 @@ struct CustomscalerWidget : ModuleWidget {
   
   CustomscalerWidget(Customscaler *module) : ModuleWidget(module) {
 	
-	setPanel(SVG::load(assetPlugin(plugin, "res/Customscaler.svg")));
+	setPanel(SVG::load(assetPlugin(plugin, "res/CustomScaler.svg")));
 
 	addChild(Widget::create<ScrewSilver>(Vec(15, 0)));
 	addChild(Widget::create<ScrewSilver>(Vec(15, 365)));


### PR DESCRIPTION
The path to load CustomScaler.svg has incorrect case. On Linux this causes the module
to be un-openable (the Module is created but its widget is invisible). This commit fixes it
by referencing the correct path.